### PR TITLE
ci(`check`): use Rust nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
+          components: rustfmt, clippy
+          override: true
       - run: make check
   test:
     name: test


### PR DESCRIPTION
<https://github.com/cfm/proxy-solver-api/blob/4aa1faebcae7a123d23f695a501dcaa744265bf1/Makefile#L13> is only available with nightly Rust.